### PR TITLE
Include /tell and /w in the aliases of /msg

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -251,7 +251,7 @@ commands:
   msg:
     description: Send a private message to another player.
     usage: /msg <user> <message>
-    aliases: ['message', 'pm']
+    aliases: ['message', 'pm', 'tell', 'w']
     permission: essence.chat.msg
   reply:
     description: Reply to the last private message sent to you.


### PR DESCRIPTION
Just a small tweak, to make sure `/tell` and `/w` are covered by `/msg` instead of being vanilla defaults