### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,6 +1,8 @@
 name: Publish project to LewMC Repo
 on:
   push:
+permissions:
+  contents: read
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ We welcome contributions from the community. Please fork the repository, make yo
 Please read [our contributor guide](CONTRIBUTING.md) before submitting any changes, thank you!
 
 Please merge any changes into the `next-update` branch, not the `main` branch.
-This helps us to ensure that our snapshot builds are labelled as snapshot so that it is clear to users download them that they are still in development, and that any changes being made will work with future versions of Essence.
+This helps us to ensure that our snapshot builds are labelled as snapshot so that it is clear to users downloading them that they are still in development, and that any changes being made will work with future versions of Essence.
 
 ## Build Process
 

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>net.lewmc</groupId>
   <artifactId>essence</artifactId>
   <name>Essence</name>
-  <version>1.10.0</version>
+  <version>1.10.1-SNAPSHOT</version>
   <build>
     <resources>
       <resource>

--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>io.papermc.paper</groupId>
       <artifactId>paper-api</artifactId>
-      <version>1.21.1-R0.1-SNAPSHOT</version>
+      <version>1.21-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>net.lewmc</groupId>
     <artifactId>essence</artifactId>
-    <version>1.10.0</version>
+    <version>1.10.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Essence</name>

--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>net.lewmc</groupId>
             <artifactId>foundry</artifactId>
-            <version>1.0.0-SNAPSHOT</version>
+            <version>1.1.0-SNAPSHOT</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/net/lewmc/essence/core/UtilImport.java
+++ b/src/main/java/net/lewmc/essence/core/UtilImport.java
@@ -96,11 +96,17 @@ public class UtilImport {
                                     (float) file.getDouble("homes." + home + ".pitch")
                             );
 
-                            utilHome.create(
+                            if (utilHome.create(
                                     home,
-                                    this.plugin.getServer().getPlayer(file.getString("last-account-name")),
+                                    this.plugin.getServer().getPlayer(child.getName().replace(".yml", "")),
                                     loc
-                            );
+                            )) {
+                                if (this.plugin.verbose) {
+                                    this.log.info("Import > Home > "+child.getName().replace(".yml", "")+ " > "+home);
+                                }
+                            } else {
+                                this.log.severe("Unable to import home "+home+" for user "+child.getName().replace(".yml", ""));
+                            }
                         }
                     }
                 }

--- a/src/main/java/net/lewmc/essence/core/UtilImport.java
+++ b/src/main/java/net/lewmc/essence/core/UtilImport.java
@@ -96,16 +96,18 @@ public class UtilImport {
                                     (float) file.getDouble("homes." + home + ".pitch")
                             );
 
+                            UUID uuid = UUID.fromString(child.getName().replace(".yml", ""));
+
                             if (utilHome.create(
                                     home,
-                                    this.plugin.getServer().getPlayer(child.getName().replace(".yml", "")),
+                                    this.plugin.getServer().getPlayer(uuid),
                                     loc
                             )) {
                                 if (this.plugin.verbose) {
                                     this.log.info("Import > Home > "+child.getName().replace(".yml", "")+ " > "+home);
                                 }
                             } else {
-                                this.log.severe("Unable to import home "+home+" for user "+child.getName().replace(".yml", ""));
+                                this.log.severe("Unable to import home "+home+" for user "+this.plugin.getServer().getPlayer(uuid)+" ("+child.getName().replace(".yml", "")+")");
                             }
                         }
                     }

--- a/src/main/java/net/lewmc/essence/core/UtilImport.java
+++ b/src/main/java/net/lewmc/essence/core/UtilImport.java
@@ -160,10 +160,10 @@ public class UtilImport {
             } else {
                 this.log.info("No Essentials spawns found!");
             }
+            file.close();
         } else {
             this.log.info("Essentials spawns file does not exist!");
         }
-        file.close();
         return success;
     }
 }

--- a/src/main/java/net/lewmc/essence/core/UtilImport.java
+++ b/src/main/java/net/lewmc/essence/core/UtilImport.java
@@ -100,14 +100,14 @@ public class UtilImport {
 
                             if (utilHome.create(
                                     home,
-                                    this.plugin.getServer().getPlayer(uuid),
+                                    this.plugin.getServer().getOfflinePlayer(uuid),
                                     loc
                             )) {
                                 if (this.plugin.verbose) {
                                     this.log.info("Import > Home > "+child.getName().replace(".yml", "")+ " > "+home);
                                 }
                             } else {
-                                this.log.severe("Unable to import home "+home+" for user "+this.plugin.getServer().getPlayer(uuid)+" ("+child.getName().replace(".yml", "")+")");
+                                this.log.severe("Unable to import home "+home+" for user "+this.plugin.getServer().getOfflinePlayer(uuid)+" ("+child.getName().replace(".yml", "")+")");
                             }
                         }
                     }

--- a/src/main/java/net/lewmc/essence/teleportation/home/UtilHome.java
+++ b/src/main/java/net/lewmc/essence/teleportation/home/UtilHome.java
@@ -5,6 +5,7 @@ import net.lewmc.essence.core.UtilMessage;
 import net.lewmc.essence.team.UtilTeam;
 import net.lewmc.foundry.Files;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 import java.util.Objects;
@@ -140,7 +141,7 @@ public class UtilHome {
      * @param loc Location - The location for the home.
      * @return boolean - If the operation was successful.
      */
-    public boolean create(String homeName, Player player, Location loc) {
+    public boolean create(String homeName, OfflinePlayer player, Location loc) {
         if (player == null) {
             return false;
         }
@@ -150,8 +151,10 @@ public class UtilHome {
 
         if (playerData.get(homeName) != null) {
             playerData.close();
-            UtilMessage message = new UtilMessage(this.plugin, player);
-            message.send("home", "alreadyexists");
+            if (player.isOnline()) {
+                UtilMessage message = new UtilMessage(this.plugin, (Player) player);
+                message.send("home", "alreadyexists");
+            }
             return false;
         }
 

--- a/src/main/java/net/lewmc/essence/teleportation/home/UtilHome.java
+++ b/src/main/java/net/lewmc/essence/teleportation/home/UtilHome.java
@@ -141,6 +141,10 @@ public class UtilHome {
      * @return boolean - If the operation was successful.
      */
     public boolean create(String homeName, Player player, Location loc) {
+        if (player == null) {
+            return false;
+        }
+
         Files playerData = new Files(this.plugin.config, this.plugin);
         playerData.load(playerData.playerDataFile(player));
 

--- a/src/main/java/net/lewmc/essence/teleportation/warp/UtilWarp.java
+++ b/src/main/java/net/lewmc/essence/teleportation/warp/UtilWarp.java
@@ -63,8 +63,9 @@ public class UtilWarp {
 
         if (warpsData.get("warps." + warpName) != null) {
             warpsData.close();
-            UtilMessage message = new UtilMessage(this.plugin, this.plugin.getServer().getPlayer(playerUUID));
-            message.send("warp", "alreadyexists");
+            if (this.plugin.getServer().getOfflinePlayer(playerUUID).isOnline()) {
+                new UtilMessage(this.plugin, this.plugin.getServer().getPlayer(playerUUID)).send("warp", "alreadyexists");
+            }
             return false;
         }
 


### PR DESCRIPTION
Potential fix for [https://github.com/LewMC/Essence/security/code-scanning/2](https://github.com/LewMC/Essence/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or job definition in `.github/workflows/maven.yml`. The best way is to add it at the job level (under `publish:`) or at the root of the workflow (before `jobs:`), specifying only the permissions required. For this workflow, which checks out code and deploys to a Maven repository using secrets, the minimal required permission is likely `contents: read`. This change should be made by inserting the following block:

```yaml
permissions:
  contents: read
```

either above the `jobs:` key (to apply to all jobs) or under the `publish:` job (to apply only to that job). Since there is only one job, either location is acceptable, but the root is preferred for clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
