### PR TITLE
fix(teleportation): Use Iterator to fix concurrent modification exception

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>net.lewmc</groupId>
   <artifactId>essence</artifactId>
   <name>Essence</name>
-  <version>1.10.2</version>
+  <version>1.11.0-SNAPSHOT</version>
   <build>
     <resources>
       <resource>

--- a/src/main/java/net/lewmc/essence/teleportation/tp/UtilTeleportRequest.java
+++ b/src/main/java/net/lewmc/essence/teleportation/tp/UtilTeleportRequest.java
@@ -46,12 +46,14 @@ public class UtilTeleportRequest {
             return false;
         }
 
-        for (Map.Entry<String, String[]> entry : this.plugin.teleportRequests.entrySet()) {
+        // 使用Iterator来安全地遍历和删除元素，避免ConcurrentModificationException
+        java.util.Iterator<Map.Entry<String, String[]>> iterator = this.plugin.teleportRequests.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<String, String[]> entry = iterator.next();
             String[] values = entry.getValue();
-            String key = entry.getKey();
 
             if (values.length > 0 && values[0].equalsIgnoreCase(requester)) {
-                this.plugin.teleportRequests.remove(key);
+                iterator.remove(); // 使用Iterator的remove方法安全删除
                 found = true;
             }
         }


### PR DESCRIPTION
Modify the traversal logic in the UtilTeleportRequest class, use Iterator to safely remove elements, and avoid ConcurrentModificationException.