### PR TITLE
Fix team disbanding failure

### DIFF
--- a/src/main/java/net/lewmc/essence/team/UtilTeam.java
+++ b/src/main/java/net/lewmc/essence/team/UtilTeam.java
@@ -408,7 +408,7 @@ public class UtilTeam {
         playerData.set("user.team", null);
         playerData.save();
 
-        return teamData.delete("teams/" + team + ".yml");
+        return teamData.delete("data/teams/" + team + ".yml");
     }
 
     /**


### PR DESCRIPTION
Currently, when running /team disband, the command fails due to attempting to delete a YML in the `teams/` directory instead of `data/teams/` directory. This pull request solves this issue.